### PR TITLE
Potential fix for order of maven targets

### DIFF
--- a/build_package.sh
+++ b/build_package.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 mvn clean
+mvn compile
 mvn package
-
+mvn assembly:single


### PR DESCRIPTION
This is a bit weird because a fresh pull doesn't seem to work but
trying again does. Added `compile` and `test` targets to hopefully
resolve ordering/dependence issues.

Yeah, I wrote this. Contribution by Killian.